### PR TITLE
feat: support marking packages as bundled

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 Toolchain for building Vue framework libraries.
 
+-   Hybrid ESM/CJS packages.
+-   Transpiled with Babel.
+-   Supports monorepo.
+
+## Configuration
+
+### Bundled dependencies
+
+By default all dependencies (`dependencies` and `peerDependencies`) are marked as external and not bundled in output files.
+This can be overriden by setting `externalDependencies` in `package.json`:
+
+```diff
+     "dependencies": {
+         "lodash": "^4.17.20"
+     },
++    "externalDependencies": [
++        "lodash"
++    ],
+```
+
 ## Usage
 
 ### `babel.config.js`

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -30,6 +30,7 @@ interface PackageJson {
     version: string;
     dependencies?: Record<string, string>;
     peerDependencies?: Record<string, string>;
+    externalDependencies?: string[];
 }
 
 function isExternal(externals: Array<string | RegExp>, name: string): boolean {
@@ -83,8 +84,12 @@ const vueMajor = detectVueMajor();
 const packageJson = readJsonFile("package.json") as PackageJson;
 const dependencies = Object.keys(packageJson.dependencies ?? {});
 const peerDependencies = Object.keys(packageJson.peerDependencies ?? {});
+const externalDependencies = packageJson.externalDependencies;
 const allDependencies = [...dependencies, ...peerDependencies].sort();
-const external = new Set([...allDependencies]);
+const external = new Set([
+    ...(externalDependencies ?? dependencies),
+    ...peerDependencies,
+]);
 
 console.log(
     "Building",


### PR DESCRIPTION
`externalDependencies` fungerar bra med andra verktyg.