### PR TITLE
fix: do not throw inside lookupFile

### DIFF
--- a/src/utils/lookupFile.ts
+++ b/src/utils/lookupFile.ts
@@ -8,8 +8,6 @@ export function lookupFile(nameWithoutExtension: string): string {
             return fileName;
         }
     }
-
-    throw new Error(
-        `Entry is missing. ${nameWithoutExtension}.{${extensions.join(",")}}`,
-    );
+    /* No file found, return default file extension and let Esbuild / Vite fail later on */
+    return `${nameWithoutExtension}.ts`;
 }


### PR DESCRIPTION
In FKUI (and also internal monorepos) is using vite-lib when starting Cypress component tests, and previous [PR](https://github.com/Forsakringskassan/vite-lib-config/pull/39) broke this functionality.


FKUI LOG:
https://github.com/Forsakringskassan/designsystem/actions/runs/12988966837/job/36221043399?pr=219

I removed the `throw` from lookupFile so Cypress components will be able run again, and Esbuild / Vite will fail later on if entry is not found while building the library.