### PR TITLE
feat(api-extractor): handle `declare global` augmentations

### DIFF
--- a/src/utils/extract-augmentations.spec.ts
+++ b/src/utils/extract-augmentations.spec.ts
@@ -2,7 +2,7 @@ import dedent from "dedent";
 import { extractAugmentations } from "./extract-augmentations";
 
 describe("extractAugmentations()", () => {
-    it("should find global external augmentation", () => {
+    it("should find module augmentation", () => {
         expect.assertions(2);
         const content = dedent`
             declare module "foo" {
@@ -28,7 +28,37 @@ describe("extractAugmentations()", () => {
         `);
     });
 
-    it("should find multiple global external augmentations", () => {
+    it("should find global augmentation", () => {
+        expect.assertions(2);
+        const content = dedent`
+            declare global {
+                namespace foo {
+                    interface Bar {
+                        /**
+                         * Does something useful
+                         */
+                        usefulFunction(): void;
+                    }
+                }
+            }
+        `;
+        const result = extractAugmentations(content);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchInlineSnapshot(`
+            "declare global {
+                namespace foo {
+                    interface Bar {
+                        /**
+                         * Does something useful
+                         */
+                        usefulFunction(): void;
+                    }
+                }
+            }"
+        `);
+    });
+
+    it("should find multiple augmentations", () => {
         expect.assertions(3);
         const content = dedent`
             declare module "foo" {

--- a/src/utils/extract-augmentations.ts
+++ b/src/utils/extract-augmentations.ts
@@ -5,10 +5,10 @@ import dedent from "dedent";
  */
 export function extractAugmentations(content: string): string[] {
     const matches = content.matchAll(
-        /^declare module\s*"([^"]+)"\s*{([^]+?)^}/gm,
+        /^declare (?:module\s*"([^"]+)"|global)\s*{([^]+?)^}/gm,
     );
     return Array.from(matches).map((it) => {
-        const [withDeclaration, name, withoutDeclaration] = it;
+        const [withDeclaration, name = "", withoutDeclaration] = it;
 
         /* if the augmentation refers to a local file we exclude the "declare
          * module" block itself, if it refers to an external package we include


### PR DESCRIPTION
Lägger in stöd för att `--patch-augmentations` ska hantera `declare global`. Idag hanterar den bara `declare module "foo"`.

Det behövs för att `@fkui/test-utils` använder `declare global´ för att augmentera jest matchers och de ligger i `global`, vilket i förlängningen krävs för att ändra `moduleResultion` till `bundler` så som vi sa på synk-möte. Idag ligger det inne med ett fulhack som slutar fungera med `bundler`, inte förvånande kanske.