### PR TITLE
fix: define dynamic fileName in dist folder (refs SB-4982)

### DIFF
--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -162,7 +162,7 @@ const defaultConfig = {
         },
         rollupOptions: {
             output: {
-                entryFileNames: `index.[custom-format].js`,
+                entryFileNames: `[name].[custom-format].js`,
                 globals: {
                     vue: "Vue",
                 },


### PR DESCRIPTION
Om du själv skickar in egen config med list utav entrypoints så blev filnamnen i dist alltid hårdkodade till **index.cjs**, **index2.cjs** osv.

Denna ändring innebär att filnamnen i dist kommer förbli input-namnet, som till standard är just index (så borde inte vara brytande..)

För att trigga problemet så kan du exempelvis ha följande konfig:
```javascript
import { defineConfig } from "@forsakringskassan/vite-lib-config/vite";
...
defineConfig({
    build: {
        lib: {
            entry: ["src/index.ts", "src/dev.ts"],
        },
    },
});

```

Filer i dist (ett urval)
```
index.cjs.js
index.cjs.js.map
index.cjs2.js
index.cjs2.js.map
index-CLBF49eD.js
index-CLBF49eD.js.map
```