### PR TITLE
feat: new bin `fk-build-selectors` to build selectors and pageobjects

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Toolchain for building Vue framework libraries.
 - Hybrid ESM/CJS packages.
 - Transpiled with Babel.
 - Supports monorepo.
+- Optional: build pageobjects and selectors.
 
 ## Configuration
 
@@ -81,6 +82,21 @@ To fix global module augmentations use:
 > fk-api-extractor --patch-augmentations
 
 Use `--help` to see full description.
+
+### Optional: build pageobjects and selectors
+
+```diff
+ {
+     "scripts": {
+         "build": "fk-build-vue-lib",
++        "build:selectors": "fk-build-selectors",
+     }
+ }
+```
+
+If `src/selectors/index.ts` it will be built to `dist/${format}/selectors.${cjs,mjs}`.
+
+If `src/cypress/index.ts` it will be built to `dist/${format}/cypress.${cjs,mjs}`.
 
 ### Dev-server
 

--- a/bin/build-selectors.mjs
+++ b/bin/build-selectors.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+
+import { run } from "../dist/build-selectors.js";
+
+const argv = process.argv.slice(2);
+
+try {
+    await run(argv);
+} catch (err) {
+    console.error(err);
+    process.exitCode = 1;
+}

--- a/build.mjs
+++ b/build.mjs
@@ -56,6 +56,7 @@ async function run() {
         entryPoints: [
             "src/api-extractor.ts",
             "src/babel.config.ts",
+            "src/build-selectors.ts",
             "src/index.ts",
         ],
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
     "": {
       "name": "@forsakringskassan/vite-lib-config",
       "version": "4.6.9",
-      "dev": true,
       "license": "MIT",
       "workspaces": [
         "testbed"
@@ -20,6 +19,7 @@
         "@vue/babel-preset-app": "5.0.9",
         "dedent": "1.7.2",
         "deepmerge": "4.3.1",
+        "esbuild": "^0.28.0",
         "find-up": "8.0.0",
         "glob": "13.0.6",
         "is-ci": "4.1.0",
@@ -29,6 +29,7 @@
       },
       "bin": {
         "fk-api-extractor": "bin/api-extractor.js",
+        "fk-build-selectors": "bin/build-selectors.mjs",
         "fk-build-vue-lib": "bin/build-vue-lib.mjs"
       },
       "devDependencies": {
@@ -51,7 +52,6 @@
         "@types/jest": "29.5.14",
         "@types/node": "20.19.39",
         "@types/semver": "7.7.1",
-        "esbuild": "0.28.0",
         "npm-pkg-lint": "4.6.5",
         "npm-run-all2": "8.0.4",
         "ts-node": "10.9.2",
@@ -7505,7 +7505,6 @@
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
       "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "types": "./dist/index.d.ts",
   "bin": {
     "fk-api-extractor": "bin/api-extractor.js",
-    "fk-build-vue-lib": "bin/build-vue-lib.mjs"
+    "fk-build-vue-lib": "bin/build-vue-lib.mjs",
+    "fk-build-selectors": "bin/build-selectors.mjs"
   },
   "files": [
     "*.d.ts",
@@ -78,6 +79,7 @@
     "@vue/babel-preset-app": "5.0.9",
     "dedent": "1.7.2",
     "deepmerge": "4.3.1",
+    "esbuild": "^0.28.0",
     "find-up": "8.0.0",
     "glob": "13.0.6",
     "is-ci": "4.1.0",
@@ -105,7 +107,6 @@
     "@types/jest": "29.5.14",
     "@types/node": "20.19.39",
     "@types/semver": "7.7.1",
-    "esbuild": "0.28.0",
     "npm-pkg-lint": "4.6.5",
     "npm-run-all2": "8.0.4",
     "ts-node": "10.9.2",
@@ -128,6 +129,7 @@
   "externalDependencies": [
     "@microsoft/api-extractor",
     "@vue/babel-preset-app",
+    "esbuild",
     "vite"
   ]
 }

--- a/src/build-selectors.ts
+++ b/src/build-selectors.ts
@@ -1,0 +1,57 @@
+import { existsSync } from "node:fs";
+import path from "node:path/posix";
+import * as esbuild from "esbuild";
+
+const extension = {
+    cjs: ".cjs",
+    esm: ".mjs",
+} as const;
+
+async function build(
+    entrypoint: string,
+    formats: readonly ["cjs", "esm"],
+): Promise<void> {
+    if (!existsSync(entrypoint)) {
+        return;
+    }
+
+    /* "src/cypress/index.ts" -> "cypress" */
+    const basename = path.basename(path.dirname(entrypoint));
+
+    for (const format of formats) {
+        const result = await esbuild.build({
+            entryPoints: [entrypoint],
+            outfile: `dist/${format}/${basename}.${format}.js`,
+            bundle: true,
+            platform: "browser",
+            format,
+            target: "chrome119",
+            sourcemap: true,
+            outExtension: {
+                ".js": extension[format],
+            },
+            logLevel: "info",
+            metafile: true,
+        });
+        if (format === "esm") {
+            const output = await esbuild.analyzeMetafile(result.metafile);
+            console.log(output);
+        }
+    }
+}
+
+export async function run(argv: string[]): Promise<void> {
+    const flags = new Set(argv.filter((it) => it.startsWith("--")));
+
+    if (flags.has("--help")) {
+        console.log("usage: fk-build-selectors [OPTIONS..]");
+        console.log(`
+  --help                     Show this help.
+`);
+    }
+
+    const formats = ["cjs", "esm"] as const;
+
+    await build("src/cypress/index.ts", formats);
+    await build("src/selectors/index.ts", formats);
+}


### PR DESCRIPTION
Ersätter [build-pageobjects.mjs](https://github.com/Forsakringskassan/designsystem/blob/main/packages/vue/build-pageobjects.mjs) i respektive tillämpning.